### PR TITLE
Fix name resolution hierarchy when using imports

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -124,7 +124,7 @@ module.exports = function(schema, extraEncodings) {
     }
   }
 
-  visit(schema, '')
+  visit(schema, schema.package !== null ? schema.package : '')
 
   var compileEnum = function(e) {
     var conditions = Object.keys(e.values)

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function(proto, opts) {
     var sch = (typeof proto === 'object' && !Buffer.isBuffer(proto)) ? proto : schema.parse(proto)
     sch.imports.forEach(function(filename) {
       if (importedFiles.hasOwnProperty(filename)) return
-      if (typeof opts.resolveImport !== 'function') throw new Error('.proto requires import, but resolveImport did not implemented.')
+      if (typeof opts.resolveImport !== 'function') throw new Error('.proto requires import, but resolveImport function not provided.')
       processImport(opts.resolveImport(filename), true)
       importedFiles[filename] = 1
     })


### PR DESCRIPTION
This allows you to have a proto file which references things in an imported proto by using an unqualified name, if the imported proto is in a 'parent' package.

In other words, this tricks things into following the protocol buffers [name resolution rules](https://developers.google.com/protocol-buffers/docs/proto#packages-and-name-resolution) better.
